### PR TITLE
Re-position 'highlightElement' on window resize

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -118,7 +118,6 @@ export default Service.extend(Evented, {
     $('#highlightOverlay').remove();
     const currentElement = this.getElementForStep(step);
     if (currentElement) {
-      const elementPosition = getElementPosition(currentElement);
       const highlightElement = $(currentElement).clone();
       highlightElement.attr('id', 'highlightOverlay');
       $('body').append(highlightElement);
@@ -132,13 +131,10 @@ export default Service.extend(Evented, {
           window.getComputedStyle(children[i]).cssText;
       }
 
-      highlightElement.css({
-        'position': 'absolute',
-        'left': elementPosition.left,
-        'top': elementPosition.top,
-        'width': elementPosition.width,
-        'height': elementPosition.height,
-        'z-index': 10002
+      this.setPositionForHighlightElement({currentElement, highlightElement});
+
+      Ember.$(window).on('resize', () => {
+        run.debounce(this, 'setPositionForHighlightElement', {currentElement, highlightElement}, 50);
       });
     }
   },
@@ -288,6 +284,26 @@ export default Service.extend(Evented, {
       });
     }
     return allElementsPresent;
+  },
+
+  /**
+   * Set position of the highlighted element
+   *
+   * @param currentElement The element that belongs to the step
+   * @param highlightElement The cloned element that is above the overlay
+   * @private
+   */
+  setPositionForHighlightElement({currentElement, highlightElement}) {
+    const elementPosition = getElementPosition(currentElement);
+
+    highlightElement.css({
+      'position': 'absolute',
+      'left': elementPosition.left,
+      'top': elementPosition.top,
+      'width': elementPosition.width,
+      'height': elementPosition.height,
+      'z-index': 10002
+    });
   },
 
   /**


### PR DESCRIPTION
Create a method called `setPositionForHighlightElement`. 

- This method is called in `createHighlightOverlay` to set the default position of the highlighted element. 

- We also call this method within a `run.debounce` on `resize` of the window to make sure the highlighted item is always at the same place and follows the viewport width.

--
![reposition-highlight-element](https://cloud.githubusercontent.com/assets/744426/16054757/8b9b15ae-323c-11e6-8710-dce1796fa720.gif)

--
Relates to #16 
