### PR TITLE
Pass through scrollToHandler option

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -449,7 +449,7 @@ export default Service.extend(Evented, {
       let $window = $(window);
 
       // Allow scrollbar scrolling so scrollTo works.
-      if (currentStep.options.scrollToHandler) {
+      if (currentStep.options.scrollToHandler === 'undefined') {
         currentStep.options.scrollToHandler = (elem) => {
           $window.disablescroll({
             handleScrollbar: false

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -449,17 +449,19 @@ export default Service.extend(Evented, {
       let $window = $(window);
 
       // Allow scrollbar scrolling so scrollTo works.
-      currentStep.options.scrollToHandler = (elem) => {
-        $window.disablescroll({
-          handleScrollbar: false
-        });
+      if (currentStep.options.scrollToHandler) {
+        currentStep.options.scrollToHandler = (elem) => {
+          $window.disablescroll({
+            handleScrollbar: false
+          });
 
-        if (typeof elem !== 'undefined') {
-          elem.scrollIntoView();
-        }
+          if (typeof elem !== 'undefined') {
+            elem.scrollIntoView();
+          }
 
-        $window.disablescroll(this.get('disableScroll') ? undefined : 'undo');
-      };
+          $window.disablescroll(this.get('disableScroll') ? undefined : 'undo');
+        };
+      }
 
     });
     if (this.get('autoStart')) {


### PR DESCRIPTION
This change prevents ember-shepherd from overriding a custom scrollToHandler in the options passed to the tour service.