### PR TITLE
ember-tether version fix

### DIFF
--- a/blueprints/ember-shepherd/index.js
+++ b/blueprints/ember-shepherd/index.js
@@ -6,7 +6,7 @@ module.exports = {
   afterInstall: function(options) {
     return this.addAddonsToProject({
       packages: [
-        {name: 'ember-tether'}
+        { name: 'ember-tether', target: '0.3.1' }
       ]
     })
   }


### PR DESCRIPTION
adding version number to install for ember-tether, since it is causing install problems when you have `peerDependency` to `0.3.1` and it installs `ember-tether 4.0.0` and then npm complains that `peerDependency` for ember-tether is `0.3.1` and it got `4.0.0`