### PR TITLE
Apply `highlightClass` to `currentElement` when `tour.modal == false`

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -449,15 +449,18 @@ export default Service.extend(Evented, {
       const currentStep = tour.steps[index];
 
       currentStep.on('before-show', () => {
-        if (this.get('modal')) {
-          const currentElement = this.getElementForStep(currentStep);
-
-          if (currentElement) {
+        const currentElement = this.getElementForStep(currentStep);
+        if (currentElement) {
+          if (this.get('modal')) {
             currentElement.style.pointerEvents = 'none';
             if (currentStep.options.copyStyles) {
               this.createHighlightOverlay(currentStep);
             } else {
               this.popoutElement(currentStep);
+            }
+          } else {
+            if (currentStep.options.highlightClass) {
+              $(currentElement).addClass(step.options.highlightClass);
             }
           }
         }

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -350,19 +350,28 @@ export default Service.extend(Evented, {
   },
 
   /**
-   * Increases the z-index of the element, to pop it out above the overlay and highlight it
+   * Modulates the styles of the passed step's target element, based on the step's options and
+   * the tour's `modal` option, to visually emphasize the element
    *
    * @param step The step object that attaches to the element
    * @private
    */
   popoutElement(step) {
-    $('.shepherd-modal').removeClass('shepherd-modal');
     const currentElement = this.getElementForStep(step);
 
     if (currentElement) {
-      $(currentElement).addClass('shepherd-modal');
       if (step.options.highlightClass) {
         $(currentElement).addClass(step.options.highlightClass);
+      }
+
+      if (this.get('modal')) {
+        currentElement.style.pointerEvents = 'none';
+        $('.shepherd-modal').removeClass('shepherd-modal');
+        $(currentElement).addClass('shepherd-modal');
+      }
+
+      if (step.options.copyStyles) {
+        this.createHighlightOverlay(step);
       }
     }
   },
@@ -449,21 +458,7 @@ export default Service.extend(Evented, {
       const currentStep = tour.steps[index];
 
       currentStep.on('before-show', () => {
-        const currentElement = this.getElementForStep(currentStep);
-        if (currentElement) {
-          if (this.get('modal')) {
-            currentElement.style.pointerEvents = 'none';
-            if (currentStep.options.copyStyles) {
-              this.createHighlightOverlay(currentStep);
-            } else {
-              this.popoutElement(currentStep);
-            }
-          } else {
-            if (currentStep.options.highlightClass) {
-              $(currentElement).addClass(step.options.highlightClass);
-            }
-          }
-        }
+        this.popoutElement(currentStep);
       });
       currentStep.on('hide', () => {
         // Remove element copy, if it was cloned

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -366,12 +366,13 @@ export default Service.extend(Evented, {
 
       if (this.get('modal')) {
         currentElement.style.pointerEvents = 'none';
-        $('.shepherd-modal').removeClass('shepherd-modal');
-        $(currentElement).addClass('shepherd-modal');
-      }
 
-      if (step.options.copyStyles) {
-        this.createHighlightOverlay(step);
+        if (step.options.copyStyles) {
+          this.createHighlightOverlay(step);
+        } else {
+          $('.shepherd-modal').removeClass('shepherd-modal');
+          $(currentElement).addClass('shepherd-modal');
+        }
       }
     }
   },

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -182,6 +182,47 @@ test('Highlight applied', function(assert) {
   });
 });
 
+test('Highlight applied when `tour.modal == false`', function(assert) {
+  assert.expect(2);
+
+  const steps = [{
+    id: 'test-highlight',
+    options: {
+      attachTo: '.first-element bottom',
+      builtInButtons: [
+        {
+          classes: 'shepherd-button-secondary cancel-button',
+          text: 'Exit',
+          type: 'cancel'
+        },
+        {
+          classes: 'shepherd-button-primary next-button',
+          text: 'Next',
+          type: 'next'
+        }
+      ],
+      classes: 'shepherd shepherd-open shepherd-theme-arrows shepherd-transparent-text',
+      copyStyles: false,
+      highlightClass: 'highlight',
+      title: 'Welcome to Ember-Shepherd!',
+      text: ['Testing highlight']
+    }
+  }];
+
+  visit('/');
+
+  andThen(function() {
+    tour.set('steps', steps);
+    click('.toggleHelpNonmodal');
+
+    andThen(function() {
+      assert.equal(find('.highlight', 'body').length, 1, 'currentElement highlighted');
+      patchClick('.shepherd-content a:contains(Exit)', 'body');
+      assert.equal(find('.highlight', 'body').length, 0, 'highlightClass removed on cancel');
+    });
+  });
+});
+
 test('Defaults applied', function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
I'm currently implementing a tutorial with this library (thank you!) where I do not want to dim the entire page, but would like to apply a specific highlight class to the target of `attachTo` when a given step is active.

I was surprised to find that the `highlightClass` option for a step is only applied within the [`popoutElement` service method](https://github.com/shipshapecode/ember-shepherd/blob/460e6e3f0fb4e14ed2130e0df747b1a80f54d9b8/addon/services/tour.js#L358), which itself is only called [here](https://github.com/shipshapecode/ember-shepherd/blob/460e6e3f0fb4e14ed2130e0df747b1a80f54d9b8/addon/services/tour.js#L460) when `tour.modal == true` and `currentStep.options.copyStyles == false`.

I'm wondering if it's a principled decision to restrict the usage of `highlightClass` to this set of conditions. This PR adds a path that applies `step.options.highlightClass` to the target element when `tour.modal == false`; let me know what you think.