### PR TITLE
Adding condition for disableScroll property in scrollToHandler.

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -383,7 +383,9 @@ export default Service.extend(Evented, {
           }
 
           run.later(() => {
-            disableScroll.on(window);
+            if (get(this, 'disableScroll')) {
+              disableScroll.on(window);
+            }
           }, 50);
         };
       }


### PR DESCRIPTION
We noticed that we weren't able to scroll our app while a tour was in progress, even when `disableScroll` was set to `false`. There was a call to the `disableScroll` plugin in the `scrollToHandler` that wasn't checking if `disableScroll` was enabled. 

Thanks for all the great work!