### PR TITLE
Cleaning up tour artifacts when tour service is destroyed.

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -10,7 +10,8 @@ import {
   getElementForStep,
   removeElement,
   setPositionForHighlightElement,
-  toggleShepherdModalClass
+  toggleShepherdModalClass,
+  cleanupShepherdElements
 } from '../utils';
 
 export default Service.extend(Evented, {
@@ -27,13 +28,7 @@ export default Service.extend(Evented, {
   steps: [],
 
   willDestroy() {
-    document.body.classList.remove('shepherd-active');
-    document.querySelectorAll('[class^=shepherd]').forEach((el) => {
-      el.parentNode.removeChild(el);
-    });
-    document.querySelectorAll('[id^=shepherd]').forEach((el) => {
-      el.parentNode.removeChild(el);
-    });
+    cleanupShepherdElements();
     this.cleanup();
   },
 

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -26,6 +26,17 @@ export default Service.extend(Evented, {
   requiredElements: [],
   steps: [],
 
+  willDestroy() {
+    document.body.classList.remove('shepherd-active');
+    document.querySelectorAll('[class^=shepherd]').forEach((el) => {
+      el.parentNode.removeChild(el);
+    });
+    document.querySelectorAll('[id^=shepherd]').forEach((el) => {
+      el.parentNode.removeChild(el);
+    });
+    this.cleanup();
+  },
+
   /**
    * Get the tour object and call back
    * @public

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -145,11 +145,22 @@ function toggleShepherdModalClass(currentElement) {
   currentElement.classList.add('shepherd-modal');
 }
 
+function cleanupShepherdElements() {
+  document.body.classList.remove('shepherd-active');
+  document.querySelectorAll('[class^=shepherd]').forEach((el) => {
+    el.parentNode.removeChild(el);
+  });
+  document.querySelectorAll('[id^=shepherd]').forEach((el) => {
+    el.parentNode.removeChild(el);
+  });
+}
+
 export {
   elementIsHidden,
   getElementForStep,
   getElementPosition,
   removeElement,
   setPositionForHighlightElement,
-  toggleShepherdModalClass
+  toggleShepherdModalClass,
+  cleanupShepherdElements
 };

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -23,18 +23,6 @@ module('Acceptance | Tour functionality tests', function(hooks) {
     });
   });
 
-  hooks.afterEach(async function() {
-    // Remove all Shepherd stuff, to start fresh each time.
-    document.body.classList.remove('shepherd-active');
-    document.querySelectorAll('[class^=shepherd]').forEach((el) => {
-      el.parentNode.removeChild(el);
-    });
-    document.querySelectorAll('[id^=shepherd]').forEach((el) => {
-      el.parentNode.removeChild(el);
-    });
-    tour.cleanup();
-  });
-
   test('Shows cancel link', async function(assert) {
     await visit('/');
 


### PR DESCRIPTION
When writing application tests using pages that have shepherd tours, we've had to copy the `afterEach` hook from `ember-shepherd`'s tests to have the tour torn down after each test (https://github.com/shipshapecode/ember-shepherd/blob/master/tests/acceptance/ember-shepherd-test.js#L26-L36). Rather than having to copy that for each test, I've added a `willDestroy` method to the `tour` service that should clean up the tour when the application is torn down automatically.