### PR TITLE
Document required elements order; add requiredElements tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,19 +79,6 @@ this.get('tour').set('defaultStepOptions', {
 
 > **default value:** `{}`
 
-### disableScroll
-
-`disableScroll` is a boolean, that when set to true, will keep the user from scrolling with the scrollbar,
-mousewheel, arrow keys, etc. You may want to use this to ensure you are driving the scroll position with the tour.
-Thanks to [jquery-disablescroll](https://github.com/ultrapasty/jquery-disablescroll) for this functionality.
-
-> **default value:** `false`
-
-### modal
-
-`modal` is a boolean, that should be set to true, if you would like the rest of the screen, other than the current element, greyed out, and the current element highlighted. If you do not need modal functionality, you can remove this option or set it to false.
-
-> **default value:** `false`
 
 ### requiredElements
 
@@ -99,6 +86,8 @@ Thanks to [jquery-disablescroll](https://github.com/ultrapasty/jquery-disablescr
 exist and be visible for the tour to start. If any elements are not present, it will keep the tour from starting.
 
 You can also specify a message, which will tell the user what they need to do to make the tour work.
+
+**⚠️ You must set `requiredElements` *BEFORE* setting steps.**
 
 _Example_
 ```js
@@ -117,6 +106,27 @@ this.get('tour').set('requiredElements', [
 ```
 
 > **default value:** `[]`
+
+
+### disableScroll
+
+`disableScroll` is a boolean, that when set to true, will keep the user from scrolling with the scrollbar,
+mousewheel, arrow keys, etc. You may want to use this to ensure you are driving the scroll position with the tour.
+Thanks to [jquery-disablescroll](https://github.com/ultrapasty/jquery-disablescroll) for this functionality.
+
+> **default value:** `false`
+
+### modal
+
+`modal` is a boolean, that should be set to true, if you would like the rest of the screen, other than the current element, greyed out, and the current element highlighted. If you do not need modal functionality, you can remove this option or set it to false.
+
+> **default value:** `false`
+
+### modalContainer
+
+`modalContainer` configures where in the DOM the modal overlay element will be placed (only has effect if `modal` is set to `true`)
+
+> **default value:** `body`
 
 
 ### addSteps

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -2,7 +2,7 @@ import { module, test } from 'qunit';
 import { visit, click, find } from '@ember/test-helpers';
 import { later } from '@ember/runloop';
 import { setupApplicationTest } from 'ember-qunit';
-import { builtInButtons } from '../data';
+import { builtInButtons, steps as defaultSteps } from '../data';
 
 import {
   elementIds as modalElementIds,
@@ -73,6 +73,57 @@ module('Acceptance | Tour functionality tests', function(hooks) {
       await click(document.querySelector('.shepherd-content a.shepherd-cancel-link'));
 
       assert.notOk(document.body.classList.contains('shepherd-active'), 'Body does not have class of shepherd-active, when shepherd becomes inactive');
+    });
+  });
+
+  module('Required Elements', function () {
+    test('Not warning about required elements when none are specified', async function(assert) {
+      await visit('/');
+      await click('.toggleHelpModal');
+
+      const currentStepId = document.body.getAttribute('data-shepherd-step');
+
+      assert.equal(currentStepId, defaultSteps[0].id);
+    });
+
+
+    test('Not warning about required elements when none are missing', async function(assert) {
+      const requiredElements = [
+        {
+          selector: 'body',
+          message: 'Body element not found 🤔',
+          title: 'Error'
+        },
+      ];
+
+      tour.set('requiredElements', requiredElements);
+
+      await visit('/');
+      await click('.toggleHelpModal');
+
+      const currentStepId = document.body.getAttribute('data-shepherd-step');
+
+      assert.equal(currentStepId, defaultSteps[0].id);
+    });
+
+
+    test('Warning about missing required elements when all are present', async function(assert) {
+      const requiredElements = [
+        {
+          selector: '👻',
+          message: '👻 element not found',
+          title: 'Missing Required Elements'
+        },
+      ];
+
+      tour.set('requiredElements', requiredElements);
+
+      await visit('/');
+      await click('.toggleHelpModal');
+
+      const currentStepId = document.body.getAttribute('data-shepherd-step');
+
+      assert.equal(currentStepId, 'error');
     });
   });
 

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -16,19 +16,8 @@ export default Route.extend({
     tour.set('disableScroll', this.get('disableScroll'));
     tour.set('modal', true);
     tour.set('confirmCancel', false);
+
     tour.addSteps(defaultSteps);
-    tour.set('requiredElements', [
-      {
-        selector: '.first-element',
-        message: 'First element not found',
-        title: 'Error'
-      },
-      {
-        selector: '.install-element',
-        message: 'Install element not found',
-        title: 'Error'
-      }
-    ]);
 
     tour.on('cancel', () => {
       console.log('cancel');


### PR DESCRIPTION
I noticed that `requiredElements` needs to be set before `steps` -- because that's when we actually perform the check for their presence.

I updated the dummy app to reflect this, too.