### PR TITLE
Rename `defaults` to `defaultStepOptions`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ confirm window on cancel, to ensure you want to cancel.
 `confirmCancelMessage` is a string to display in the confirm dialog when `confirmCancel`
 is set to true.
 
-### defaults
+### defaultStepOptions
 
-`defaults` is used to set the options that will be applied to each step by default.
+`defaultStepOptions` is used to set the options that will be applied to each step by default.
 You can pass in any of the options that you can with Shepherd.
 
-**⚠️ You must set defaults *BEFORE* setting steps.**
+**⚠️ You must set `defaultStepOptions` *BEFORE* setting steps.**
 
 It will be an object of a form something like:
 
 ```js
-this.get('tour').set('defaults', {
+this.get('tour').set('defaultStepOptions', {
   classes: 'custom-class-name-1 custom-class-name-2',
   scrollTo: false,
   showCancelLink: true

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -18,7 +18,7 @@ export default Service.extend(Evented, {
   // Configuration Options
   confirmCancel: false,
   confirmCancelMessage: null,
-  defaults: {},
+  defaultStepOptions: {},
   disableScroll: false,
   errorTitle: null,
   isActive: false,
@@ -171,12 +171,12 @@ export default Service.extend(Evented, {
   initialize() {
     const confirmCancel = get(this, 'confirmCancel');
     const confirmCancelMessage = get(this, 'confirmCancelMessage');
-    const defaults = get(this, 'defaults');
+    const defaultStepOptions = get(this, 'defaultStepOptions');
 
     const tourObject = new Shepherd.Tour({
       confirmCancel,
       confirmCancelMessage,
-      defaults
+      defaultStepOptions
     });
 
     tourObject.on('start', run.bind(this, 'onTourStart'));

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "ember-cli-node-assets": "0.2.2",
     "ember-getowner-polyfill": "^2.2.0",
     "fastboot-transform": "^0.1.3",
-    "shepherd.js": "^2.0.0-beta.26"
+    "shepherd.js": "^2.0.0-beta.27"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -27,7 +27,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
   });
 
   test('Hides cancel link', async function(assert) {
-    const defaults = {
+    const defaultStepOptions = {
       classes: 'shepherd-theme-arrows test-defaults',
       showCancelLink: false
     };
@@ -46,7 +46,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
     await visit('/');
 
-    tour.set('defaults', defaults);
+    tour.set('defaultStepOptions', defaultStepOptions);
     tour.set('steps', steps);
 
     await click('.toggleHelpModal');

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -8,7 +8,7 @@ import { steps as defaultSteps } from '../data';
 export default Route.extend({
   tour: service(),
   disableScroll: true,
-  defaults: {
+  defaultStepOptions: {
     classes: 'shepherd-theme-arrows custom-default-class',
     scrollTo: true,
     showCancelLink: true
@@ -17,7 +17,7 @@ export default Route.extend({
   beforeModel() {
     const tour = this.get('tour');
 
-    tour.set('defaults', this.get('defaults'));
+    tour.set('defaultStepOptions', this.get('defaultStepOptions'));
     tour.set('disableScroll', this.get('disableScroll'));
     tour.set('modal', true);
     tour.set('confirmCancel', false);

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -20,7 +20,7 @@
       {{~#code-block language='javascript'~}}
 //Inject the service: tour: Ember.inject.service()
 let tour = this.get('tour');
-tour.set('defaults', shepherdDefaults);
+tour.set('defaultStepOptions', shepherdDefaults);
 tour.set('disableScroll', true);
 tour.set('modal', true);
 tour.set('requiredElements', requiredElements);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8198,9 +8198,9 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
-shepherd.js@^2.0.0-beta.26:
-  version "2.0.0-beta.26"
-  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-2.0.0-beta.26.tgz#04d8e5dfa8aba7d873d4314183b1e56e4acb7f4e"
+shepherd.js@^2.0.0-beta.27:
+  version "2.0.0-beta.27"
+  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-2.0.0-beta.27.tgz#09b6744fc902fccb1dce482cd7af12422a3d48cd"
   dependencies:
     element-matches "^0.1.2"
     lodash-es "^4.17.10"


### PR DESCRIPTION
Corresponds to https://github.com/shipshapecode/shepherd/pull/244.

⚠️ Marking as a WIP these changes are based on the aforementioned PR in `shepherd`. Ideally, we could cut a new beta release after merging that -- and then upgrade our `shepherd` version here.