### PR TITLE
Stop disabling target element pointer events

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,13 @@ Extra classes to apply to the step, for styling purposes and such.
 > **default value:** `''`
 
 
+#### canClickTarget
+
+Whether or not the target element being attached to should be "clickable". If set to `false`, Ember Shepherd sets the element's [`pointerEvents` style](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) to `none` while the step is active.
+
+> **default value:** `true`
+
+
 ##### copyStyles
 
 This is a boolean, and when set to `true` it will fully clone the element and styles, rather than just increasing the element's z-index. This should only be used if the element does not pop out and highlight like it should, when using modal functionality.

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -306,27 +306,55 @@ module('Acceptance | Tour functionality tests', function(hooks) {
     assert.ok(buttonActionCalled, 'button action triggered');
   });
 
-  test('`pointer-events` is set to `auto` for any step element on clean up', async function(assert) {
-    assert.expect(2);
+  test('`pointer-events` is set to `auto` for any previously disabled `attachTo` targets', async function(assert) {
+      const steps = [
+        {
+          id: 'step-1',
+          options: {
+            attachTo: '.shepherd-logo-link top',
+            builtInButtons: [
+              builtInButtons.cancel,
+              builtInButtons.next,
+            ],
+            title: 'Controlling Clickability',
+            text: 'By default, target elements should have their `pointerEvents` style unchanged',
+          },
+        },
+        {
+          id: 'step-2',
+          options: {
+            attachTo: '.shepherd-logo-link top',
+            canClickTarget: false,
+            builtInButtons: [
+              builtInButtons.cancel,
+            ],
+            title: 'Controlling Clickability',
+            text: 'Clickability of target elements can be disabled by setting `canClickTarget` to false',
+          }
+        },
+      ];
 
-    await visit('/');
+      await visit('/');
 
-    await click('.toggleHelpModal');
+      tour.set('steps', steps);
+      tour.set('modal', true);
 
-    // Go through a step of the tour...
-    await click(document.querySelector('[data-id="intro"] .next-button'));
+      await click('.toggleHelpModal');
 
-    // Get the target element
-    const targetElement = document.querySelector('.shepherd-target');
+      // Get the target element
+      const targetElement = document.querySelector('.shepherd-target');
 
-    // Check the target element has pointer-events = 'none'
-    assert.equal(targetElement.style.pointerEvents, 'none');
+      assert.equal(getComputedStyle(targetElement)['pointer-events'], 'auto');
 
-    // Exit the tour
-    await click(document.querySelector('[data-id="installation"] .cancel-button'));
+      // Exit the tour
+      await click(document.querySelector('[data-id="step-1"] .next-button'));
 
-    // Check the target element now has pointer-events = 'auto'
-    assert.equal(targetElement.style.pointerEvents, 'auto');
+      assert.equal(getComputedStyle(targetElement)['pointer-events'], 'none');
+
+      // Exit the tour
+      await click(document.querySelector('[data-id="step-2"] .cancel-button'));
+
+      assert.equal(getComputedStyle(targetElement)['pointer-events'], 'auto');
   });
 
   test('scrollTo works with disableScroll on', async function(assert) {

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -70,6 +70,7 @@ a {
   font-size: 0.75em;
   margin-bottom: 1.25rem;
   padding: 1.25rem;
+  text-align: center;
 }
 
 .button.dark {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -68,7 +68,7 @@ tour.cancel();
       </centered>
     </hbox>
     <centered class="medium-8 columns medium-centered text-center">
-      <a href="https://github.com/HubSpot/shepherd">
+      <a href="https://github.com/shipshapecode/shepherd" class="shepherd-logo-link">
         <svg xmlns="http://www.w3.org/2000/svg" version="1.0" style="height: 330px; width: 330px; max-width: 80%;"
              viewBox="0 0 128 128">
           <g>


### PR DESCRIPTION
I got started on a branch in `shepherd` that will allow for [a `disableAttachTarget` step option](https://github.com/shipshapecode/shepherd/compare/add-option-to-disable-target-pointer-events).

In the meantime, though, we can get started with the corresponding change here.