### PR TITLE
Remove cleanupShepherdElements

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -9,8 +9,7 @@ import {
   getElementForStep,
   removeElement,
   setPositionForHighlightElement,
-  toggleShepherdModalClass,
-  cleanupShepherdElements
+  toggleShepherdModalClass
 } from '../utils';
 
 export default Service.extend(Evented, {
@@ -28,7 +27,6 @@ export default Service.extend(Evented, {
   steps: [],
 
   willDestroy() {
-    cleanupShepherdElements();
     this.cleanup();
   },
 

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -145,22 +145,11 @@ function toggleShepherdModalClass(currentElement) {
   currentElement.classList.add('shepherd-modal');
 }
 
-function cleanupShepherdElements() {
-  document.body.classList.remove('shepherd-active');
-  document.querySelectorAll('[class^=shepherd]').forEach((el) => {
-    el.parentNode.removeChild(el);
-  });
-  document.querySelectorAll('[id^=shepherd]').forEach((el) => {
-    el.parentNode.removeChild(el);
-  });
-}
-
 export {
   elementIsHidden,
   getElementForStep,
   getElementPosition,
   removeElement,
   setPositionForHighlightElement,
-  toggleShepherdModalClass,
-  cleanupShepherdElements
+  toggleShepherdModalClass
 };

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -1,5 +1,6 @@
 import { module, test } from 'qunit';
 import { visit, click, find } from '@ember/test-helpers';
+import { later } from '@ember/runloop';
 import { setupApplicationTest } from 'ember-qunit';
 import { builtInButtons } from '../data';
 
@@ -354,6 +355,9 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
   test('scrollTo works with a custom scrollToHandler', async function(assert) {
     assert.expect(2);
+
+    const done = assert.async();
+
     // Override default behavior
     const steps = [{
       id: 'intro',
@@ -365,7 +369,11 @@ module('Acceptance | Tour functionality tests', function(hooks) {
         ],
         scrollTo: true,
         scrollToHandler() {
-          return document.querySelector('#ember-testing-container').scrollTop = 120;
+          document.querySelector('#ember-testing-container').scrollTop = 120;
+          return later(() => {
+            assert.equal(document.querySelector('#ember-testing-container').scrollTop, 120, 'Scrolled correctly');
+            done();
+          }, 50);
         }
       }
     }];
@@ -380,8 +388,6 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
     await click('.toggleHelpModal');
     await click(document.querySelector('.shepherd-content .next-button'));
-
-    assert.equal(document.querySelector('#ember-testing-container').scrollTop, 120, 'Scrolled correctly');
   });
 
   test('scrollTo works without a custom scrollToHandler', async function(assert) {

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -3,7 +3,6 @@ import { visit, click, find } from '@ember/test-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { builtInButtons } from '../data';
 
-
 module('Acceptance | Tour functionality tests', function(hooks) {
   let tour;
 
@@ -116,11 +115,13 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
     await click('.toggleHelpModal');
 
-    assert.ok(document.querySelector('.highlight'), 'currentElement highlighted');
+    assert.ok(tour.get('tourObject').currentStep.target.classList.contains('highlight'),
+      'currentElement has highlightClass applied');
 
-    await click(document.querySelector('.shepherd-content .cancel-button'));
+    await click(document.querySelector('.cancel-button'));
 
-    assert.notOk(document.querySelector('.highlight'), 'highlightClass removed on cancel');
+    assert.notOk(tour.get('tourObject').currentStep.target.classList.contains('highlight'),
+      'highlightClass removed on cancel');
   });
 
   test('Highlight applied when `tour.modal == false`', async function(assert) {
@@ -145,11 +146,13 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
     await click('.toggleHelpNonmodal');
 
-    assert.ok(document.querySelector('.highlight'), 'currentElement highlighted');
+    assert.ok(tour.get('tourObject').currentStep.target.classList.contains('highlight'),
+      'currentElement has highlightClass applied');
 
-    await click(document.querySelector('.shepherd-content .cancel-button'));
+    await click(document.querySelector('.cancel-button'));
 
-    assert.notOk(document.querySelector('.highlight'), 'highlightClass removed on cancel');
+    assert.notOk(tour.get('tourObject').currentStep.target.classList.contains('highlight'),
+      'highlightClass removed on cancel');
   });
 
   test('Defaults applied', async function(assert) {
@@ -378,7 +381,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
     await click('.toggleHelpModal');
     await click(document.querySelector('.shepherd-content .next-button'));
 
-    assert.ok(document.querySelector('#ember-testing-container').scrollTop === 120, 'Scrolled correctly');
+    assert.equal(document.querySelector('#ember-testing-container').scrollTop, 120, 'Scrolled correctly');
   });
 
   test('scrollTo works without a custom scrollToHandler', async function(assert) {
@@ -399,12 +402,14 @@ module('Acceptance | Tour functionality tests', function(hooks) {
     assert.ok(document.querySelector('#ember-testing-container').scrollTop > 0, 'Scrolled correctly');
   });
 
-  test('Shows by id works', async function(assert) {
+  test('Show by id works', async function(assert) {
+    assert.expect(1);
+
     await visit('/');
 
     tour.show('usage');
 
-    assert.equal(document.querySelector('.shepherd-element .shepherd-text').textContent,
+    assert.equal(tour.get('tourObject').currentStep.el.querySelector('.shepherd-text').textContent,
       'To use the tour service, simply inject it into your application and use it like this example.',
       'Usage step shown');
   });


### PR DESCRIPTION
We should not need `cleanupShepherdElements` anymore, since Shepherd cleans up after itself. 

Resolves #246 