### PR TITLE
Hide modal when hiding the current step

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Whether or not the target element being attached to should be "clickable". If se
 
 ##### highlightClass
 
-This is an extra class to apply to the attachTo element, when it is highlighted. It can be any string. Just style that class name in your css.
+This is an extra class to apply to the attachTo element when it is highlighted (that is, when its step is active). It can be any string. Just style that class name in your CSS.
 
 > **default value:** ``
 

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -286,7 +286,7 @@ export default Service.extend(Evented, {
       });
 
       currentStep.on('hide', () => {
-        // Remove element copy, if it was cloned
+        // Remove any modal and target-element highlight styling
         const targetElement = getElementForStep(currentStep);
 
         if (targetElement) {
@@ -294,7 +294,7 @@ export default Service.extend(Evented, {
             targetElement.classList.remove(currentStep.options.highlightClass);
           }
 
-          closeModalOpening(this._modalOverlayOpening);
+          this.hideModal();
         }
       });
 


### PR DESCRIPTION
We shouldn't be worried about the modal opening here -- we should just need to toggle the `display`.