### PR TITLE
Use Ember.set to set `this.tourObject`

### DIFF
--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -130,7 +130,7 @@ export default Service.extend(Evented, {
     tourObject.on('complete', run.bind(this, 'onTourFinish', 'complete'));
     tourObject.on('cancel', run.bind(this, 'onTourFinish', 'cancel'));
 
-    this.tourObject = tourObject;
+    set(this, 'tourObject', tourObject);
     this.initModalOverlay();
   },
 


### PR DESCRIPTION
Fixes a regression from #248. 

This should prevent the following error I saw when reinitializing the current `tourObject`:

<img width="1422" alt="screen shot 2018-09-21 at 6 25 03 pm" src="https://user-images.githubusercontent.com/5483853/45913152-63d59380-bde2-11e8-8ecd-80883d1d9859.png">
