### PR TITLE
Block clicks outside of visible modal opening.

### DIFF
--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -17,6 +17,12 @@
   -ms-transition: all 0.3s ease-out;
   -o-transition: all 0.3s ease-out;
   transition: all 0.3s ease-out;
+
+  /**
+   * Block all clicks except for those that would occur
+   * on the modals "unfilled" (in the SVG sense) opening.
+   */
+  pointer-events: visibleFill;
 }
 
 


### PR DESCRIPTION
Uses the `pointer-events: visibleFill` rule to block all clicks except
for those that would occur on the modals "unfilled" (in the SVG sense) opening.