### PR TITLE
Possible support for IE

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-node-assets": "0.2.2",
     "fastboot-transform": "^0.1.3",
-    "shepherd.js": "^2.5.0"
+    "shepherd.js": "2.4.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11050,10 +11050,10 @@ shellwords@^0.1.1:
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
 
-shepherd.js@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-2.5.0.tgz#c8fdc1fbaff55f1e021c930178d0e2b1cea7a7e3"
-  integrity sha512-DesuIO0wqlCWP6tWU/g5Qt//OfapVEamnvLBWwCBUB/AbrPtWomngi7MJmmkulTJGQz8F6FGnc3TSXK6bM9cOA==
+shepherd.js@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/shepherd.js/-/shepherd.js-2.4.0.tgz#eab2b251dc207424c09411d47cbcbde160923780"
+  integrity sha512-69kCm7Qs5lz0lwfWxBa9H3er06G1pfg4H7UORKObltkycfeMPckl/cKQNamrwKJjq71xtFQgNlG/eCO7TRJQdw==
   dependencies:
     element-matches "^0.1.2"
     lodash-es "^4.17.11"


### PR DESCRIPTION
This PR probably isn't the right answer, but I'm submitting as a discussion point.

I very much understand the desire to get rid of IE support, but sadly, some of us still have to support it.

Would it be possible to have some kind of compatibility release that does what's here (basically pinning shepherd to 2.4.0)

Would be nice to have this plus an explicit shoutout in the README to say if you need IE support, then release XXX is the highest possible version you can use.