### PR TITLE
load shepherd.js lazily using ember-auto-import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: 'babel-eslint',
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'module'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "6"
+  - "8"
 
 sudo: false
 dist: trusty

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -11,6 +11,7 @@ import {
   elementIsHidden
 } from '../utils/dom';
 import { disableBodyScroll, enableBodyScroll, clearAllBodyScrollLocks } from 'body-scroll-lock';
+import { Promise } from 'rsvp';
 
 /**
  * Interaction with `ember-shepherd` is done entirely through the Tour service, which you can access from any object using the `Ember.inject` syntax:
@@ -156,6 +157,13 @@ export default Service.extend(Evented, {
   requiredElements: [],
   steps: [],
 
+  init() {
+    this._super(...arguments);
+    let owner = getOwner(this);
+    const fastboot = owner.lookup('service:fastboot');
+    this.fastboot = fastboot && fastboot.isFastBoot;
+  },
+
   willDestroy() {
     this._cleanup();
   },
@@ -222,6 +230,9 @@ export default Service.extend(Evented, {
    * @public
    */
   addSteps(steps) {
+    if (this.fastboot) {
+      return Promise.resolve();
+    }
     return this._initialize().then(() => {
       const tour = get(this, 'tourObject');
 
@@ -282,6 +293,9 @@ export default Service.extend(Evented, {
    * @public
    */
   back() {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').back();
     this.trigger('back');
   },
@@ -293,6 +307,9 @@ export default Service.extend(Evented, {
    * @public
    */
   cancel() {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').cancel();
   },
 
@@ -303,6 +320,9 @@ export default Service.extend(Evented, {
    * @public
    */
   complete() {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').complete();
   },
 
@@ -313,6 +333,9 @@ export default Service.extend(Evented, {
    * @public
    */
   hide() {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').hide();
   },
 
@@ -323,6 +346,9 @@ export default Service.extend(Evented, {
    * @public
    */
   next() {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').next();
     this.trigger('next');
   },
@@ -335,6 +361,9 @@ export default Service.extend(Evented, {
    * @public
    */
   show(id) {
+    if (this.fastboot) {
+      return;
+    }
     get(this, 'tourObject').show(id);
   },
 
@@ -345,6 +374,9 @@ export default Service.extend(Evented, {
    * @public
    */
   start() {
+    if (this.fastboot) {
+      return;
+    }
     set(this, 'isActive', true);
     get(this, 'tourObject').start();
   },

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -161,7 +161,7 @@ export default Service.extend(Evented, {
     this._super(...arguments);
     let owner = getOwner(this);
     const fastboot = owner.lookup('service:fastboot');
-    this.fastboot = fastboot && fastboot.isFastBoot;
+    this._isFastBoot = fastboot && fastboot.isFastBoot;
   },
 
   willDestroy() {
@@ -230,7 +230,7 @@ export default Service.extend(Evented, {
    * @public
    */
   addSteps(steps) {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return Promise.resolve();
     }
     return this._initialize().then(() => {
@@ -293,7 +293,7 @@ export default Service.extend(Evented, {
    * @public
    */
   back() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').back();
@@ -307,7 +307,7 @@ export default Service.extend(Evented, {
    * @public
    */
   cancel() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').cancel();
@@ -320,7 +320,7 @@ export default Service.extend(Evented, {
    * @public
    */
   complete() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').complete();
@@ -333,7 +333,7 @@ export default Service.extend(Evented, {
    * @public
    */
   hide() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').hide();
@@ -346,7 +346,7 @@ export default Service.extend(Evented, {
    * @public
    */
   next() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').next();
@@ -361,7 +361,7 @@ export default Service.extend(Evented, {
    * @public
    */
   show(id) {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     get(this, 'tourObject').show(id);
@@ -374,7 +374,7 @@ export default Service.extend(Evented, {
    * @public
    */
   start() {
-    if (this.fastboot) {
+    if (this._isFastBoot) {
       return;
     }
     set(this, 'isActive', true);

--- a/addon/services/tour.js
+++ b/addon/services/tour.js
@@ -169,7 +169,8 @@ export default Service.extend(Evented, {
   },
 
   /**
-   * Take a set of steps and create a tour object based on the current configuration
+   * Take a set of steps, create a tour object based on the current configuration and load the shepherd.js dependency.
+   * This method returns a promise which resolves when the shepherd.js dependency has been loaded and shepherd is ready to use.
    *
    * You must pass an array of steps to `addSteps`, something like this:
    *
@@ -227,6 +228,7 @@ export default Service.extend(Evented, {
    *
    * @method addSteps
    * @param {array} steps An array of steps
+   * @returns {Promise} Promise that resolves when everything has been set up and shepherd is ready to use
    * @public
    */
   addSteps(steps) {
@@ -368,7 +370,7 @@ export default Service.extend(Evented, {
   },
 
   /**
-   * Start the tour
+   * Start the tour. The Promise from addSteps() must be in a resolved state prior to starting the tour!
    *
    * @method start
    * @public
@@ -377,8 +379,12 @@ export default Service.extend(Evented, {
     if (this._isFastBoot) {
       return;
     }
+    const tourObject = get(this, 'tourObject');
+    if (tourObject == undefined) {
+      throw new Error("the Promise from addSteps must be in a resolved state before the tour can be started");
+    }
     set(this, 'isActive', true);
-    get(this, 'tourObject').start();
+    tourObject.start();
   },
 
   /**

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
 
 module.exports = function(defaults) {
   const app = new EmberAddon(defaults, {
+    babel: {
+      plugins: [ require.resolve('ember-auto-import/babel-plugin') ]
+    },
     sassOptions: {
       includePaths: [
         'node_modules/shepherd.js/src/scss'

--- a/index.js
+++ b/index.js
@@ -1,37 +1,16 @@
 'use strict';
 
-const fastbootTransform = require('fastboot-transform');
-
 module.exports = {
   name: require('./package').name,
   included(app) {
     if (app.options && app.options.shepherd && app.options.shepherd.theme) {
-      this.theme = `dist/css/shepherd-theme-${app.options.shepherd.theme}.css`;
+      app.import(`node_modules/shepherd.js/dist/css/shepherd-theme-${app.options.shepherd.theme}.css`);
     }
-
     this._super.included.apply(this, arguments);
   },
   options: {
     babel: {
       plugins: [ require.resolve('ember-auto-import/babel-plugin') ]
-    },
-    nodeAssets: {
-      'shepherd.js'() {
-        const include = [];
-
-        if (this.theme) {
-          include.push(this.theme);
-        }
-
-        return {
-          import: {
-            include,
-            processTree(tree) {
-              return fastbootTransform(tree);
-            }
-          }
-        };
-      }
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -12,11 +12,12 @@ module.exports = {
     this._super.included.apply(this, arguments);
   },
   options: {
+    babel: {
+      plugins: [ require.resolve('ember-auto-import/babel-plugin') ]
+    },
     nodeAssets: {
       'shepherd.js'() {
-        const include = [
-          'dist/js/shepherd.js'
-        ];
+        const include = [];
 
         if (this.theme) {
           include.push(this.theme);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "body-scroll-lock": "^2.6.1",
     "ember-auto-import": "^1.2.21",
     "ember-cli-babel": "^7.1.2",
-    "ember-cli-node-assets": "0.2.2",
     "fastboot-transform": "^0.1.3",
     "shepherd.js": "^2.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",
+    "babel-eslint": "^10.0.1",
     "broccoli-asset-rev": "^3.0.0",
     "codeclimate-test-reporter": "^0.5.1",
     "ember-cli": "~3.9.0",

--- a/tests/acceptance/ember-shepherd-test.js
+++ b/tests/acceptance/ember-shepherd-test.js
@@ -5,7 +5,7 @@ import { builtInButtons, steps as defaultSteps } from '../data';
 
 const toggleTour = async (tour, modal) => {
   tour.set('modal', modal);
-  tour.addSteps(defaultSteps);
+  await tour.addSteps(defaultSteps);
   return await tour.start();
 };
 
@@ -56,7 +56,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
       await visit('/docs/demo');
 
       tour.set('defaultStepOptions', defaultStepOptions);
-      tour.addSteps(steps);
+      await tour.addSteps(steps);
 
       tour.start();
 
@@ -149,7 +149,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
       await visit('/docs/demo');
 
-      tour.addSteps(stepsWithoutClasses);
+      await tour.addSteps(stepsWithoutClasses);
 
       tour.start();
 
@@ -173,7 +173,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
         }
       }];
 
-      tour.addSteps(steps);
+      await tour.addSteps(steps);
 
       await visit('/docs/demo');
 
@@ -201,7 +201,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
         }
       }];
 
-      tour.addSteps(steps);
+      await tour.addSteps(steps);
       tour.start();
 
       assert.ok(document.querySelector('.shepherd-element'), 'tour is visible');
@@ -241,7 +241,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
 
       await visit('/docs/demo');
 
-      tour.addSteps(steps);
+      await tour.addSteps(steps);
 
       await tour.start();
 
@@ -302,7 +302,7 @@ module('Acceptance | Tour functionality tests', function(hooks) {
       // Visit route
       await visit('/docs/demo');
 
-      tour.addSteps(steps);
+      await tour.addSteps(steps);
 
       document.querySelector('#ember-testing-container').scrollTop = 0;
       assert.equal(document.querySelector('#ember-testing-container').scrollTop, 0, 'Scroll is initially 0');

--- a/tests/dummy/app/routes/docs/demo.js
+++ b/tests/dummy/app/routes/docs/demo.js
@@ -9,7 +9,7 @@ export default Route.extend({
   tour: service(),
   disableScroll: true,
 
-  beforeModel() {
+  async beforeModel() {
     const tour = this.get('tour');
 
     tour.set('defaultStepOptions', defaultStepOptions);
@@ -25,7 +25,7 @@ export default Route.extend({
       });
     }
 
-    tour.addSteps(defaultSteps);
+    await tour.addSteps(defaultSteps);
 
     tour.on('cancel', () => {
       console.log('cancel');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1678,6 +1678,18 @@ babel-core@^6.24.1, babel-core@^6.26.0, babel-core@^6.26.3:
     slash "^1.0.0"
     source-map "^0.5.7"
 
+babel-eslint@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.0.1.tgz#919681dc099614cd7d31d45c8908695092a1faed"
+  integrity sha512-z7OT1iNV+TjOwHNLLyJk+HN+YVWX+CLE6fPD2SymJZOZQBs+QIexFjhm4keGTm8MW9xr4EC9Q0PbaLB24V5GoQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
+
 babel-generator@^6.26.0:
   version "6.26.1"
   resolved "https://registry.yarnpkg.com/babel-generator/-/babel-generator-6.26.1.tgz#1844408d3b8f0d35a404ea7ac180f087a601bd90"
@@ -5733,6 +5745,14 @@ eslint-plugin-node@^8.0.0:
     minimatch "^3.0.4"
     resolve "^1.8.1"
     semver "^5.5.0"
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
fixes #304 

This is at an early stage, but I wanted give a chance to review the main concept first. For now I return promises both for the `_initialize` as well as the `addSteps` method. Please let me know in case you prefer to use something like async/await instead (I don't have much experience using async/await yet, so not totally sure how that would work out). 
Currently this allows to start a tour like:

```
this.tour.addSteps([

   ... steps

]).then(() => {
  // shepherd has been loaded
  this.tour.start();
})
```
So, pretty much `addSteps` trigger the loading of `shepherd.js`.

Regarding the default theme: This is currently bundled the way it was using node-assets. I tried to find a way to lazy load it or at least include it using auto-import, however have not been successful so far. Currently the css theme gets appended to the app (if one is configured) while the shepherd.js lib is lazily loaded. I think this should not be much of an issue, as the css theme is relatively small. But, let me know if I should look further into if we could use auto-import for that.
